### PR TITLE
Add user badge calculation based on reputation and post count

### DIFF
--- a/src/user/badges.js
+++ b/src/user/badges.js
@@ -8,6 +8,8 @@ module.exports = function (User) {
         const postCount = await user.getUserField(uid, 'postcount');
         const userBadges = [];
 
+        // users can have multiple badges based on
+        // reputation and post count statistics
         if (reputation > 5) {
             userBadges.push('⭐');
         } else if (reputation > 20) {

--- a/src/user/badges.js
+++ b/src/user/badges.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const async = require('async');
+const nconf = require('nconf');
+const validator = require('validator');
+
+const db = require('../database');
+const user = require('../user');
+
+module.exports = function (User) {
+    User.calculateBadge = async function (uid) {
+        const reputation = await user.getUserField(uid, 'reputation');
+        const postCount = await user.getUserField(uid, 'postcount');
+        const userBadges = [];
+
+        if (reputation > 5) {
+            userBadges.push("⭐");
+        } else if (reputation > 20) {
+            userBadges.push("🌟");
+        } else {
+            userBadges.push("💫");
+        }
+
+        if (postCount > 5) {
+            userBadges.push("🌱");
+        } else if (postCount > 20) {
+            userBadges.push("🌷");
+        } else {
+            userBadges.push("🌳");
+        }
+
+        return userBadges.join("")
+    };
+};

--- a/src/user/badges.js
+++ b/src/user/badges.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const user = require('./user');
+const user = require('../user');
 
 module.exports = function (User) {
     User.calculateBadge = async function (uid) {

--- a/src/user/badges.js
+++ b/src/user/badges.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const user = require('../user');
+const user = require('./user');
 
 module.exports = function (User) {
     User.calculateBadge = async function (uid) {
@@ -24,6 +24,6 @@ module.exports = function (User) {
             userBadges.push('🌳');
         }
 
-        return userBadges.join('')
+        return userBadges.join('');
     };
 };

--- a/src/user/badges.js
+++ b/src/user/badges.js
@@ -1,10 +1,5 @@
 'use strict';
 
-const async = require('async');
-const nconf = require('nconf');
-const validator = require('validator');
-
-const db = require('../database');
 const user = require('../user');
 
 module.exports = function (User) {
@@ -14,21 +9,21 @@ module.exports = function (User) {
         const userBadges = [];
 
         if (reputation > 5) {
-            userBadges.push("⭐");
+            userBadges.push('⭐');
         } else if (reputation > 20) {
-            userBadges.push("🌟");
+            userBadges.push('🌟');
         } else {
-            userBadges.push("💫");
+            userBadges.push('💫');
         }
 
         if (postCount > 5) {
-            userBadges.push("🌱");
+            userBadges.push('🌱');
         } else if (postCount > 20) {
-            userBadges.push("🌷");
+            userBadges.push('🌷');
         } else {
-            userBadges.push("🌳");
+            userBadges.push('🌳');
         }
 
-        return userBadges.join("")
+        return userBadges.join('')
     };
 };

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -25,7 +25,7 @@ module.exports = function (User) {
         'aboutme', 'signature', 'uploadedpicture', 'profileviews', 'reputation',
         'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
         'status', 'flags', 'followerCount', 'followingCount', 'cover:url',
-        'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason'
+        'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason',
     ];
 
     User.guestData = {

--- a/src/user/data.js
+++ b/src/user/data.js
@@ -25,7 +25,7 @@ module.exports = function (User) {
         'aboutme', 'signature', 'uploadedpicture', 'profileviews', 'reputation',
         'postcount', 'topiccount', 'lastposttime', 'banned', 'banned:expire',
         'status', 'flags', 'followerCount', 'followingCount', 'cover:url',
-        'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason',
+        'cover:position', 'groupTitle', 'mutedUntil', 'mutedReason'
     ];
 
     User.guestData = {

--- a/test/user.js
+++ b/test/user.js
@@ -3073,17 +3073,17 @@ describe('User', () => {
 
     describe('calculateBadge', () => {
         it('should return ⭐ for reputation > 5 and 🌳 for postCount <= 5', async () => {
-            const userBadges = await calculateBadge(testUid);
+            const userBadges = await User.calculateBadge(testUid);
             assert.strictEqual(userBadges, '⭐🌳');
         });
-    
+
         it('should return 🌟 for reputation > 20 and 🌷 for postCount > 20', async () => {
-            const userBadges = await calculateBadge(testUid);
+            const userBadges = await User.calculateBadge(testUid);
             assert.strictEqual(userBadges, '🌟🌷');
         });
-    
+
         it('should return 💫 for reputation <= 5 and 🌱 for postCount > 5', async () => {
-            const userBadges = await calculateBadge(testUid);
+            const userBadges = await User.calculateBadge(testUid);
             assert.strictEqual(userBadges, '💫🌱');
         });
     });

--- a/test/user.js
+++ b/test/user.js
@@ -3071,6 +3071,23 @@ describe('User', () => {
         });
     });
 
+    describe('calculateBadge', () => {
+        it('should return ⭐ for reputation > 5 and 🌳 for postCount <= 5', async () => {
+            const userBadges = await calculateBadge(testUid);
+            assert.strictEqual(userBadges, '⭐🌳');
+        });
+    
+        it('should return 🌟 for reputation > 20 and 🌷 for postCount > 20', async () => {
+            const userBadges = await calculateBadge(testUid);
+            assert.strictEqual(userBadges, '🌟🌷');
+        });
+    
+        it('should return 💫 for reputation <= 5 and 🌱 for postCount > 5', async () => {
+            const userBadges = await calculateBadge(testUid);
+            assert.strictEqual(userBadges, '💫🌱');
+        });
+    });
+
     describe('User\'s', async () => {
         let files;
 


### PR DESCRIPTION
Calculated badges for the user by using two factors: post count and user reputation, and understanding if the count of the factors was above a certain threshold.