### PR TITLE
Fix logic error in badge calculation

### DIFF
--- a/src/user/data.js
+++ b/src/user/data.js
@@ -100,17 +100,17 @@ module.exports = function (User) {
 
         // users can have multiple badges based on
         // reputation and post count statistics
-        if (user.reputation > 5) {
+        if (user.reputation < 5) {
             userBadges.push('⭐');
-        } else if (user.reputation > 20) {
+        } else if (user.reputation < 20) {
             userBadges.push('🌟');
         } else {
             userBadges.push('💫');
         }
 
-        if (user.postcount > 5) {
+        if (user.postcount < 5) {
             userBadges.push('🌱');
-        } else if (user.postcount > 20) {
+        } else if (user.postcount < 20) {
             userBadges.push('🌷');
         } else {
             userBadges.push('🌳');


### PR DESCRIPTION
Fixed a small bug in `calculateBadge` by ensuring that the post count and reputation were correctly accounted for (specifically, that a reputation and post count less than a certain threshold provided the correct badge assignment for the user).

Tested locally by running `npm run test`.