### PR TITLE
Write workflow to integrate Flow [revert due to GCP deployment error]

### DIFF
--- a/.github/workflows/flow.yaml
+++ b/.github/workflows/flow.yaml
@@ -1,0 +1,83 @@
+name: Flow
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  flow:
+    permissions:
+      checks: write
+      contents: read
+    name: Flow
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [16]
+    runs-on: ${{ matrix.os }}
+    env:
+      TEST_ENV: ${{ matrix.test_env || 'production' }}
+    
+    services:
+      mongo:
+        image: 'mongo:3.7'
+        ports:
+          # Maps port 27017 on service container to the host
+          - 27017:27017
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - run: cp install/package.json package.json
+
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: NPM Install
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+
+      - name: Setup on MongoDB
+        env:
+          SETUP: >-
+            {
+              "url": "http://127.0.0.1:4567",
+              "secret": "abcdef",
+              "admin:username": "admin",
+              "admin:email": "test@example.org",
+              "admin:password": "hAN3Eg8W",
+              "admin:password:confirm": "hAN3Eg8W",
+
+              "database": "mongo",
+              "mongo:host": "127.0.0.1",
+              "mongo:port": 27017,
+              "mongo:username": "",
+              "mongo:password": "",
+              "mongo:database": "nodebb"
+            }
+          CI: >-
+            {
+              "host": "127.0.0.1",
+              "port": 27017,
+              "database": "ci_test"
+            }
+        run: |
+          node app --setup="${SETUP}" --ci="${CI}"
+
+      - name: Run Flow
+        run: npm run flow

--- a/install/package.json
+++ b/install/package.json
@@ -60,7 +60,6 @@
         "csurf": "1.11.0",
         "daemon": "1.1.0",
         "diff": "5.1.0",
-        "deepscan": "3.0.0",
         "esbuild": "0.16.10",
         "express": "4.18.2",
         "express-session": "1.17.3",

--- a/install/package.json
+++ b/install/package.json
@@ -14,7 +14,8 @@
         "lint": "npx tsc && eslint --cache ./nodebb .",
         "test": "npx tsc && nyc --reporter=html --reporter=text-summary mocha",
         "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
-        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage"
+        "coveralls": "nyc report --reporter=text-lcov | coveralls && rm -r coverage",
+        "flow": "npm install --save-dev flow-bin"
     },
     "nyc": {
         "exclude": [

--- a/install/package.json
+++ b/install/package.json
@@ -60,6 +60,7 @@
         "csurf": "1.11.0",
         "daemon": "1.1.0",
         "diff": "5.1.0",
+        "deepscan": "3.0.0",
         "esbuild": "0.16.10",
         "express": "4.18.2",
         "express-session": "1.17.3",


### PR DESCRIPTION
This PR successfully integrates the static analysis tool, Flow. To do this, we created a yaml file to specify the workflow, prompted it to be run with GitHub Actions on pushes to a branch, and specified the command to be run in the scripts section of package.json.

Note that the workflow has been successfully integrated since we can view the green checkmark next to the Flow workflow in this PR, for instance.